### PR TITLE
Add PHPUnit tests for download URL generation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+// Minimal bootstrap for tests
+// Define stubs for WordPress functions used in FAM_File
+if (!class_exists('WP_UnitTestCase')) {
+    if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+        require_once __DIR__ . '/../vendor/autoload.php';
+    }
+    class WP_UnitTestCase extends PHPUnit\Framework\TestCase {}
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action) {
+        return 'nonce-' . $action;
+    }
+}
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($args, $url = '') {
+        $query = http_build_query($args);
+        if (strpos($url, '?') === false) {
+            return $url . '?' . $query;
+        }
+        return $url . '&' . $query;
+    }
+}
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        return 'https://example.org';
+    }
+}

--- a/tests/test-download-url.php
+++ b/tests/test-download-url.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../includes/class-fam-file.php';
+
+class Get_Download_URL_Test extends WP_UnitTestCase {
+    public function test_external_url_is_returned_directly() {
+        $file = $this->getMockBuilder(FAM_File::class)
+            ->onlyMethods(['get'])
+            ->getMock();
+        $file_obj = (object) ['external_url' => 'https://example.com/file.zip'];
+        $file->method('get')->willReturn($file_obj);
+
+        $url = $file->get_download_url(123);
+        $this->assertSame('https://example.com/file.zip', $url);
+    }
+
+    public function test_internal_file_generates_secure_url() {
+        $file = $this->getMockBuilder(FAM_File::class)
+            ->onlyMethods(['get'])
+            ->getMock();
+        $file_obj = (object) [
+            'external_url' => null
+        ];
+        $file->method('get')->willReturn($file_obj);
+
+        $url = $file->get_download_url(55);
+
+        $this->assertStringStartsWith('https://example.org?', $url);
+        $this->assertStringContainsString('fam_action=download', $url);
+        $this->assertStringContainsString('file_id=55', $url);
+        $this->assertStringContainsString('token=nonce-fam_download_55', $url);
+    }
+}


### PR DESCRIPTION
## Summary
- add phpunit configuration
- create a bootstrap that stubs WordPress helpers and test base class
- test that `get_download_url()` returns external URLs
- test that internal file URLs contain expected query params and nonce

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5ff4a1c832d81a8616fc282fd29