### PR TITLE
Fix plugin description line

### DIFF
--- a/file-archive-manager.php
+++ b/file-archive-manager.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: File Archive Manager
  * Plugin URI: https://themsah.com
- * Description: A file management system with Elementor integration for WordPress
+* Description: A file management system with Elementor integration for WordPress
  * Version: 1.4.6
  * Author: Themsah
  * Author URI: https://themsah.com


### PR DESCRIPTION
## Summary
- ensure the description header line is single-line without leading space

## Testing
- `php -l file-archive-manager.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5db1360832dbf89372932a742f2